### PR TITLE
Change router variable to optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,27 +25,34 @@ locals {
   default_name                   = "cloud-nat-${random_string.name_suffix.result}"
   nat_ips_length                 = length(var.nat_ips)
   default_nat_ip_allocate_option = local.nat_ips_length > 0 ? "MANUAL_ONLY" : "AUTO_ONLY"
-
   # locals for google_compute_router_nat
   nat_ip_allocate_option = var.nat_ip_allocate_option ? var.nat_ip_allocate_option : local.default_nat_ip_allocate_option
   name                   = var.name != "" ? var.name : local.default_name
+  router                 = var.router == "" ? google_compute_router.router[0].name : var.router
+}
+
+resource "google_compute_router" "router" {
+  count   = var.router == "" ? 1 : 0
+  name    = "${local.name}-router"
+  project = var.project_id
+  region  = var.region
+  network = var.network
+  bgp {
+    asn = var.router_asn
+  }
 }
 
 resource "google_compute_router_nat" "main" {
-  project = var.project_id
-  region  = var.region
-
-  name   = local.name
-  router = var.router
-
+  project                            = var.project_id
+  region                             = var.region
+  name                               = local.name
+  router                             = local.router
   nat_ip_allocate_option             = local.nat_ip_allocate_option
   nat_ips                            = var.nat_ips
   source_subnetwork_ip_ranges_to_nat = var.source_subnetwork_ip_ranges_to_nat
-
-  min_ports_per_vm                 = var.min_ports_per_vm
-  udp_idle_timeout_sec             = var.udp_idle_timeout_sec
-  icmp_idle_timeout_sec            = var.icmp_idle_timeout_sec
-  tcp_established_idle_timeout_sec = var.tcp_established_idle_timeout_sec
-  tcp_transitory_idle_timeout_sec  = var.tcp_transitory_idle_timeout_sec
+  min_ports_per_vm                   = var.min_ports_per_vm
+  udp_idle_timeout_sec               = var.udp_idle_timeout_sec
+  icmp_idle_timeout_sec              = var.icmp_idle_timeout_sec
+  tcp_established_idle_timeout_sec   = var.tcp_established_idle_timeout_sec
+  tcp_transitory_idle_timeout_sec    = var.tcp_transitory_idle_timeout_sec
 }
-

--- a/main.tf
+++ b/main.tf
@@ -28,12 +28,12 @@ locals {
   # locals for google_compute_router_nat
   nat_ip_allocate_option = var.nat_ip_allocate_option ? var.nat_ip_allocate_option : local.default_nat_ip_allocate_option
   name                   = var.name != "" ? var.name : local.default_name
-  router                 = var.router == "" ? google_compute_router.router[0].name : var.router
+  router                 = var.create_router ? google_compute_router.router[0].name : var.router
 }
 
 resource "google_compute_router" "router" {
-  count   = var.router == "" ? 1 : 0
-  name    = "${local.name}-router"
+  count   = var.create_router ? 1 : 0
+  name    = var.router
   project = var.project_id
   region  = var.region
   network = var.network

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,6 @@ output "region" {
 
 output "router_name" {
   description = "Cloud NAT router name"
-  value       = var.router
+  value       = local.router
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,52 +23,63 @@ variable "region" {
 }
 
 variable "icmp_idle_timeout_sec" {
-  description = "(Optional) Timeout (in seconds) for ICMP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."
+  description = "Timeout (in seconds) for ICMP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."
   default     = "30"
 }
 
 variable "min_ports_per_vm" {
-  description = "(Optional) Minimum number of ports allocated to a VM from this NAT config. Defaults to 64 if not set. Changing this forces a new NAT to be created."
+  description = "Minimum number of ports allocated to a VM from this NAT config. Defaults to 64 if not set. Changing this forces a new NAT to be created."
   default     = "64"
 }
 
 variable "name" {
-  description = "(Optional) Defaults to 'cloud-nat-RANDOM_SUFFIX'. Changing this forces a new NAT to be created."
+  description = "Defaults to 'cloud-nat-RANDOM_SUFFIX'. Changing this forces a new NAT to be created."
   default     = ""
 }
 
 variable "nat_ip_allocate_option" {
-  description = "(Optional) Value inferred based on nat_ips. If present set to MANUAL_ONLY, otherwise AUTO_ONLY."
+  description = "Value inferred based on nat_ips. If present set to MANUAL_ONLY, otherwise AUTO_ONLY."
   default     = "false"
 }
 
 variable "nat_ips" {
-  description = "(Optional) List of self_links of external IPs. Changing this forces a new NAT to be created."
+  description = "List of self_links of external IPs. Changing this forces a new NAT to be created."
   type        = list(string)
   default     = []
 }
 
+variable "network" {
+  description = "VPN name, only if router is not passed in and is created by the module."
+  default     = ""
+}
+
 variable "router" {
-  description = "(Required) The name of the router in which this NAT will be configured. Changing this forces a new NAT to be created."
+  description = "The name of the router in which this NAT will be configured. Changing this forces a new NAT to be created."
+  default     = ""
+}
+
+variable "router_asn" {
+  description = "Router ASN, only if router is not passed in and is created by the module."
+  default     = "64514"
 }
 
 variable "source_subnetwork_ip_ranges_to_nat" {
-  description = "(Optional) Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS. Changing this forces a new NAT to be created."
+  description = "Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS. Changing this forces a new NAT to be created."
   default     = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 
 variable "tcp_established_idle_timeout_sec" {
-  description = "(Optional) Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set. Changing this forces a new NAT to be created."
+  description = "Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set. Changing this forces a new NAT to be created."
   default     = "1200"
 }
 
 variable "tcp_transitory_idle_timeout_sec" {
-  description = "(Optional) Timeout (in seconds) for TCP transitory connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."
+  description = "Timeout (in seconds) for TCP transitory connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."
   default     = "30"
 }
 
 variable "udp_idle_timeout_sec" {
-  description = "(Optional) Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."
+  description = "Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."
   default     = "30"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,9 +53,13 @@ variable "network" {
   default     = ""
 }
 
+variable "create_router" {
+  description = "Create router instead of using an existing one, uses 'router' variable for new resource name."
+  default     = false
+}
+
 variable "router" {
   description = "The name of the router in which this NAT will be configured. Changing this forces a new NAT to be created."
-  default     = ""
 }
 
 variable "router_asn" {


### PR DESCRIPTION
In prototyping scenarios, or in situations where a router is not needed, having to create a router with a standalone resource is a bit of a bother. This PR addresses the issue by making the router input variable optional, and creating a new router inside the module if no router name is passed in.

It mirrors the way the module we used for Fabric behaved, and would simplify things for us.