### PR TITLE
Adding log_config block

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,33 +32,35 @@ Then perform the following commands on the root folder:
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name                                    | Description                                                                                                                                                                                                                                            |     Type     |              Default              | Required |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----------: | :-------------------------------: | :------: |
-| create\_router                          | Create router instead of using an existing one, uses 'router' variable for new resource name.                                                                                                                                                          |    string    |             `"false"`             |    no    |
-| icmp\_idle\_timeout\_sec                | Timeout (in seconds) for ICMP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created.                                                                                                                                   |    string    |              `"30"`               |    no    |
-| min\_ports\_per\_vm                     | Minimum number of ports allocated to a VM from this NAT config. Defaults to 64 if not set. Changing this forces a new NAT to be created.                                                                                                               |    string    |              `"64"`               |    no    |
-| name                                    | Defaults to 'cloud-nat-RANDOM_SUFFIX'. Changing this forces a new NAT to be created.                                                                                                                                                                   |    string    |               `""`                |    no    |
-| nat\_ip\_allocate\_option               | Value inferred based on nat_ips. If present set to MANUAL_ONLY, otherwise AUTO_ONLY.                                                                                                                                                                   |    string    |             `"false"`             |    no    |
-| nat\_ips                                | List of self_links of external IPs. Changing this forces a new NAT to be created.                                                                                                                                                                      | list(string) |             `<list>`              |    no    |
-| network                                 | VPN name, only if router is not passed in and is created by the module.                                                                                                                                                                                |    string    |               `""`                |    no    |
-| project\_id                             | The project ID to deploy to                                                                                                                                                                                                                            |    string    |                n/a                |   yes    |
-| region                                  | The region to deploy to                                                                                                                                                                                                                                |    string    |                n/a                |   yes    |
-| router                                  | The name of the router in which this NAT will be configured. Changing this forces a new NAT to be created.                                                                                                                                             |    string    |                n/a                |   yes    |
-| router\_asn                             | Router ASN, only if router is not passed in and is created by the module.                                                                                                                                                                              |    string    |             `"64514"`             |    no    |
-| source\_subnetwork\_ip\_ranges\_to\_nat | Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS. Changing this forces a new NAT to be created. |    string    | `"ALL_SUBNETWORKS_ALL_IP_RANGES"` |    no    |
-| subnetworks                             |                                                                                                                                                                                                                                                        |    object    |             `<list>`              |    no    |
-| tcp\_established\_idle\_timeout\_sec    | Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set. Changing this forces a new NAT to be created.                                                                                                                      |    string    |             `"1200"`              |    no    |
-| tcp\_transitory\_idle\_timeout\_sec     | Timeout (in seconds) for TCP transitory connections. Defaults to 30s if not set. Changing this forces a new NAT to be created.                                                                                                                         |    string    |              `"30"`               |    no    |
-| udp\_idle\_timeout\_sec                 | Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created.                                                                                                                                    |    string    |              `"30"`               |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| create\_router | Create router instead of using an existing one, uses 'router' variable for new resource name. | string | `"false"` | no |
+| icmp\_idle\_timeout\_sec | Timeout (in seconds) for ICMP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created. | string | `"30"` | no |
+| log\_config\_enable | Indicates whether or not to export logs | bool | `"false"` | no |
+| log\_config\_filter | Specifies the desired filtering of logs on this NAT. Valid values are: "ERRORS_ONLY", "TRANSLATIONS_ONLY", "ALL" | string | `"ALL"` | no |
+| min\_ports\_per\_vm | Minimum number of ports allocated to a VM from this NAT config. Defaults to 64 if not set. Changing this forces a new NAT to be created. | string | `"64"` | no |
+| name | Defaults to 'cloud-nat-RANDOM_SUFFIX'. Changing this forces a new NAT to be created. | string | `""` | no |
+| nat\_ip\_allocate\_option | Value inferred based on nat_ips. If present set to MANUAL_ONLY, otherwise AUTO_ONLY. | string | `"false"` | no |
+| nat\_ips | List of self_links of external IPs. Changing this forces a new NAT to be created. | list(string) | `<list>` | no |
+| network | VPN name, only if router is not passed in and is created by the module. | string | `""` | no |
+| project\_id | The project ID to deploy to | string | n/a | yes |
+| region | The region to deploy to | string | n/a | yes |
+| router | The name of the router in which this NAT will be configured. Changing this forces a new NAT to be created. | string | n/a | yes |
+| router\_asn | Router ASN, only if router is not passed in and is created by the module. | string | `"64514"` | no |
+| source\_subnetwork\_ip\_ranges\_to\_nat | Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS. Changing this forces a new NAT to be created. | string | `"ALL_SUBNETWORKS_ALL_IP_RANGES"` | no |
+| subnetworks |  | object | `<list>` | no |
+| tcp\_established\_idle\_timeout\_sec | Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set. Changing this forces a new NAT to be created. | string | `"1200"` | no |
+| tcp\_transitory\_idle\_timeout\_sec | Timeout (in seconds) for TCP transitory connections. Defaults to 30s if not set. Changing this forces a new NAT to be created. | string | `"30"` | no |
+| udp\_idle\_timeout\_sec | Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created. | string | `"30"` | no |
 
 ## Outputs
 
-| Name                      | Description            |
-| ------------------------- | ---------------------- |
-| name                      | Name of the Cloud NAT  |
+| Name | Description |
+|------|-------------|
+| name | Name of the Cloud NAT |
 | nat\_ip\_allocate\_option | NAT IP allocation mode |
-| region                    | Cloud NAT region       |
-| router\_name              | Cloud NAT router name  |
+| region | Cloud NAT region |
+| router\_name | Cloud NAT router name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -64,4 +64,16 @@ resource "google_compute_router_nat" "main" {
       secondary_ip_range_names = contains(subnetwork.value.source_ip_ranges_to_nat, "LIST_OF_SECONDARY_IP_RANGES") ? subnetwork.value.secondary_ip_range_names : []
     }
   }
+
+  dynamic "log_config" {
+    for_each = var.log_config_enable == true ? [{
+      enable = var.log_config_enable
+      filter = var.log_config_filter
+    }] : []
+
+    content {
+      enable = log_config.value.enable
+      filter = log_config.value.filter
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,14 @@ variable "subnetworks" {
   }))
   default = []
 }
+
+variable "log_config_enable" {
+  type        = bool
+  description = "Indicates whether or not to export logs"
+  default     = false
+}
+variable "log_config_filter" {
+  type        = string
+  description = "Specifies the desired filtering of logs on this NAT. Valid values are: \"ERRORS_ONLY\", \"TRANSLATIONS_ONLY\", \"ALL\""
+  default     = "ALL"
+}


### PR DESCRIPTION
The block log_config was missing https://www.terraform.io/docs/providers/google/r/compute_router_nat.html#log_config

It is now added, disabled by default.