### PR TITLE
Optional secondary_ip_range_names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,8 +61,7 @@ resource "google_compute_router_nat" "main" {
     content {
       name                     = subnetwork.value.name
       source_ip_ranges_to_nat  = subnetwork.value.source_ip_ranges_to_nat
-      secondary_ip_range_names = subnetwork.value.secondary_ip_range_names
+      secondary_ip_range_names = contains(subnetwork.value.source_ip_ranges_to_nat, "LIST_OF_SECONDARY_IP_RANGES") ? subnetwork.value.secondary_ip_range_names : []
     }
   }
 }
-


### PR DESCRIPTION
This PR to set `secondary_ip_range_names` in case of `source_ip_ranges_to_nat` contains `LIST_OF_SECONDARY_IP_RANGES` as one of its values, based on [terraform-docs](https://www.terraform.io/docs/providers/google/r/compute_router_nat.html#secondary_ip_range_names)

> - secondary_ip_range_names = list(string)
> 
>  (Optional) List of the secondary ranges of the subnetwork that are allowed to use NAT. This can be populated only if LIST_OF_SECONDARY_IP_RANGES is one of the values in sourceIpRangesToNat