### PR TITLE
feat(bgp-settings): add keepalive interval

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,8 @@ resource "google_compute_router" "router" {
   region  = var.region
   network = var.network
   bgp {
-    asn = var.router_asn
+    asn       = var.router_asn
+    keepalive = var.router_bgp_keepalive
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,11 @@ variable "router_asn" {
   default     = "64514"
 }
 
+variable "router_bgp_keepalive" {
+  description = "BGP keepalive message. Defaults to 20s if not set. Must be an integer between 20 and 60 that specifies the number of seconds for the interval."
+  default     = "20"
+}
+
 variable "source_subnetwork_ip_ranges_to_nat" {
   description = "Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS. Changing this forces a new NAT to be created."
   default     = "ALL_SUBNETWORKS_ALL_IP_RANGES"


### PR DESCRIPTION
Recent runs with this module display the following message

```
bgp {
    keepalive_interval = 0 -> 20
    # (3 unchanged attributes hidden)
}
```

This change sets the default as per [the docs](https://cloud.google.com/network-connectivity/docs/router/how-to/managing-bgp-timers) and allows for customization.