### PR TITLE
Support tcp_time_wait_timeout_sec

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -25,6 +25,7 @@ module "cloud-nat" {
   icmp_idle_timeout_sec              = "15"
   tcp_established_idle_timeout_sec   = "600"
   tcp_transitory_idle_timeout_sec    = "15"
+  tcp_time_wait_timeout_sec          = "240"
   udp_idle_timeout_sec               = "15"
   source_subnetwork_ip_ranges_to_nat = var.source_subnetwork_ip_ranges_to_nat
   subnetworks                        = var.subnetworks

--- a/test/integration/advanced/testdata/TestAdvanced.json
+++ b/test/integration/advanced/testdata/TestAdvanced.json
@@ -9,7 +9,7 @@
   "natIpAllocateOption": "MANUAL_ONLY",
   "sourceSubnetworkIpRangesToNat": "ALL_SUBNETWORKS_ALL_IP_RANGES",
   "tcpEstablishedIdleTimeoutSec": 600,
-  "tcpTimeWaitTimeoutSec": 120,
+  "tcpTimeWaitTimeoutSec": 240,
   "tcpTransitoryIdleTimeoutSec": 15,
   "udpIdleTimeoutSec": 15
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "tcp_transitory_idle_timeout_sec" {
   default     = "30"
 }
 
+variable "tcp_time_wait_timeout_sec" {
+  type        = string
+  description = "Timeout (in seconds) for TCP connections that are in TIME_WAIT state. Defaults to 120s if not set."
+  default     = "120"
+}
+
 variable "udp_idle_timeout_sec" {
   type        = string
   description = "Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."


### PR DESCRIPTION
Currently the module does not support setting this, the resource then defaults it to 120, and this overwrites any custom setting that has been set by a local-exec provisioner calling gcloud, or otherwise configured outside of terraform.

closes #72 