### PR TITLE
feat(TPG >= 4.51)!: Support tcp_time_wait_timeout_sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Then perform the following commands on the root folder:
 | source\_subnetwork\_ip\_ranges\_to\_nat | Defaults to ALL\_SUBNETWORKS\_ALL\_IP\_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL\_SUBNETWORKS\_ALL\_IP\_RANGES, ALL\_SUBNETWORKS\_ALL\_PRIMARY\_IP\_RANGES, LIST\_OF\_SUBNETWORKS. Changing this forces a new NAT to be created. | `string` | `"ALL_SUBNETWORKS_ALL_IP_RANGES"` | no |
 | subnetworks | Specifies one or more subnetwork NAT configurations | <pre>list(object({<br>    name                     = string,<br>    source_ip_ranges_to_nat  = list(string)<br>    secondary_ip_range_names = list(string)<br>  }))</pre> | `[]` | no |
 | tcp\_established\_idle\_timeout\_sec | Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set. Changing this forces a new NAT to be created. | `string` | `"1200"` | no |
+| tcp\_time\_wait\_timeout\_sec | Timeout (in seconds) for TCP connections that are in TIME\_WAIT state. Defaults to 120s if not set. | `string` | `"120"` | no |
 | tcp\_transitory\_idle\_timeout\_sec | Timeout (in seconds) for TCP transitory connections. Defaults to 30s if not set. Changing this forces a new NAT to be created. | `string` | `"30"` | no |
 | udp\_idle\_timeout\_sec | Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created. | `string` | `"30"` | no |
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -25,6 +25,7 @@ module "cloud-nat" {
   icmp_idle_timeout_sec              = "15"
   tcp_established_idle_timeout_sec   = "600"
   tcp_transitory_idle_timeout_sec    = "15"
+  tcp_time_wait_timeout_sec          = "240"
   udp_idle_timeout_sec               = "15"
   source_subnetwork_ip_ranges_to_nat = var.source_subnetwork_ip_ranges_to_nat
   subnetworks                        = var.subnetworks

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ resource "google_compute_router_nat" "main" {
   icmp_idle_timeout_sec               = var.icmp_idle_timeout_sec
   tcp_established_idle_timeout_sec    = var.tcp_established_idle_timeout_sec
   tcp_transitory_idle_timeout_sec     = var.tcp_transitory_idle_timeout_sec
+  tcp_time_wait_timeout_sec           = var.tcp_time_wait_timeout_sec
   enable_endpoint_independent_mapping = var.enable_endpoint_independent_mapping
 
   dynamic "subnetwork" {

--- a/test/integration/advanced/testdata/TestAdvanced.json
+++ b/test/integration/advanced/testdata/TestAdvanced.json
@@ -9,7 +9,7 @@
   "natIpAllocateOption": "MANUAL_ONLY",
   "sourceSubnetworkIpRangesToNat": "ALL_SUBNETWORKS_ALL_IP_RANGES",
   "tcpEstablishedIdleTimeoutSec": 600,
-  "tcpTimeWaitTimeoutSec": 120,
+  "tcpTimeWaitTimeoutSec": 240,
   "tcpTransitoryIdleTimeoutSec": 15,
   "udpIdleTimeoutSec": 15
 }

--- a/test/integration/subnetworks/testdata/TestSubnetworks.json
+++ b/test/integration/subnetworks/testdata/TestSubnetworks.json
@@ -17,7 +17,7 @@
     }
   ],
   "tcpEstablishedIdleTimeoutSec": 600,
-  "tcpTimeWaitTimeoutSec": 120,
+  "tcpTimeWaitTimeoutSec": 240,
   "tcpTransitoryIdleTimeoutSec": 15,
   "udpIdleTimeoutSec": 15
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "tcp_transitory_idle_timeout_sec" {
   default     = "30"
 }
 
+variable "tcp_time_wait_timeout_sec" {
+  type        = string
+  description = "Timeout (in seconds) for TCP connections that are in TIME_WAIT state. Defaults to 120s if not set."
+  default     = "120"
+}
+
 variable "udp_idle_timeout_sec" {
   type        = string
   description = "Timeout (in seconds) for UDP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created."

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 4.51, < 5.0"
     }
 
     random = {


### PR DESCRIPTION
Currently the module does not support setting this, the resource then defaults it to 120, and this overwrites any custom setting that has been set by a local-exec provisioner calling gcloud, or otherwise configured outside of terraform.