### PR TITLE
feat: `bgp` block can now be optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "google_compute_router" "router" {
   project = var.project_id
   region  = var.region
   network = var.network
-  
+
   dynamic "bgp" {
     for_each = var.router_asn != null ? [{
       asn                = var.router_asn


### PR DESCRIPTION
I have a customer who has not defined _(from console)_ the `bgp` block. When I use the module, it creates a change. I don't currently have the option of setting the ASN to null to avoid creating the block.

The purpose of this PR is to support my use case. To reflect a little more the google_compute_router_nat resource which doesn't require the bgp block.