### PR TITLE
feat: add drain_nat_ips support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.configureOnOpen": false
-}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create\_router | Create router instead of using an existing one, uses 'router' variable for new resource name. | `bool` | `false` | no |
+| drain\_nat\_ips | A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT. | `list(string)` | `[]` | no |
 | enable\_dynamic\_port\_allocation | Enable Dynamic Port Allocation. If minPorts is set, minPortsPerVm must be set to a power of two greater than or equal to 32. | `bool` | `false` | no |
 | enable\_endpoint\_independent\_mapping | Specifies if endpoint independent mapping is enabled. | `bool` | `false` | no |
 | icmp\_idle\_timeout\_sec | Timeout (in seconds) for ICMP connections. Defaults to 30s if not set. Changing this forces a new NAT to be created. | `string` | `"30"` | no |

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "google_compute_router_nat" "main" {
   router                              = local.router
   nat_ip_allocate_option              = local.nat_ip_allocate_option
   nat_ips                             = var.nat_ips
+  drain_nat_ips                       = var.drain_nat_ips
   source_subnetwork_ip_ranges_to_nat  = var.source_subnetwork_ip_ranges_to_nat
   min_ports_per_vm                    = var.min_ports_per_vm
   max_ports_per_vm                    = var.enable_dynamic_port_allocation ? var.max_ports_per_vm : null

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "nat_ips" {
   default     = []
 }
 
+variable "drain_nat_ips" {
+  type        = list(string)
+  description = "A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT."
+  default     = []
+}
+
 variable "network" {
   type        = string
   description = "VPN name, only if router is not passed in and is created by the module."


### PR DESCRIPTION
In this PR I'm including support for the field drain_nat_ips.

This functionality is very useful, when turned on, Cloud NAT IP address will be in Drain mode, meaning that the Cloud NAT IP does not accept any new connections.

Ref: [https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat#drain_nat_ips](url)